### PR TITLE
Create shelves put security

### DIFF
--- a/server/routes/manuscript.router.js
+++ b/server/routes/manuscript.router.js
@@ -51,13 +51,11 @@ router.get("/writersdesk", rejectUnauthenticated, (req, res) => {
     });
 });
 
-
 /**
  * GET Single  Manuscripts route
  */
 router.get("/:id", (req, res) => {
-
-  const id = req.params.id
+  const id = req.params.id;
 
   const query = `SELECT "manuscripts".id, "manuscripts".title, "manuscripts".body, "manuscripts".public, "user".username FROM "manuscripts"
     JOIN "manuscript_shelf" ON "manuscript_shelf".manuscript_id = "manuscripts".id
@@ -81,9 +79,9 @@ router.get("/:id", (req, res) => {
  * POST Manuscript route
  */
 router.post("/", rejectUnauthenticated, async (req, res) => {
-  title = req.body.title;
-  body = req.body.body;
-  public = req.body.public;
+  const title = req.body.title;
+  const body = req.body.body;
+  const public = req.body.public;
 
   const connection = await pool.connect();
   try {
@@ -98,7 +96,7 @@ router.post("/", rejectUnauthenticated, async (req, res) => {
     const manuscriptResult = await connection.query(manuscriptInsertQueryText, [
       title,
       body,
-      public
+      public,
     ]);
     const newManuscriptId = manuscriptResult.rows[0].id;
 
@@ -142,17 +140,43 @@ router.post("/", rejectUnauthenticated, async (req, res) => {
  */
 router.put("/:id", rejectUnauthenticated, async (req, res) => {
   // const userId = req.user.id;
+
+  console.log("req", req);
+
   const manuscriptId = req.params.id;
   const title = req.body.payload.title;
   const body = req.body.payload.body;
   const public = req.body.payload.public;
 
-  const userId = req.user.id;
+  const userParamId = req.user.id;
 
   const connection = await pool.connect();
   try {
     await connection.query("BEGIN");
 
+    //Check to make sure content to be updated exists and belongs to the currently authenticated user.
+    const isManuscriptOwnerQueryText = `
+    SELECT EXISTS (
+      SELECT * FROM "user" AS u
+      JOIN "shelves" AS s ON u.id = s.user_id
+      JOIN "manuscript_shelf" AS ms ON ms.shelf_id = s.id
+      JOIN "manuscripts" AS m ON m.id = ms.manuscript_id
+      WHERE u.id = $1 AND m.id = $2
+    ) AS is_manuscript_owner;
+    `;
+
+    const isOwnerResult = await connection.query(isManuscriptOwnerQueryText, [
+      userParamId,
+      manuscriptId,
+    ]);
+    const isOwner = isOwnerResult.rows[0].is_manuscript_owner;
+    console.log("isOwnerBool", isOwner);
+
+    //If the content does not exist or does not belong to the user, we send 403 status forbidden and break.
+    if (!isOwner) {
+      res.sendStatus(403);
+      return;
+    }
     //NOT SECURE FROM POSTMAN NEED TO UPDATE TO INCLUDE USER ID
     const manuscriptUpdateQueryText = `UPDATE "manuscripts"
     SET title = $1, body = $2, public = $3
@@ -191,26 +215,45 @@ router.delete("/:id", rejectUnauthenticated, async (req, res) => {
   try {
     await connection.query("BEGIN");
 
+    //Check to make sure content to be deleted exists and belongs to the currently authenticated user.
+    const isManuscriptOwnerQueryText = `
+    SELECT EXISTS (
+      SELECT * FROM "user" AS u
+      JOIN "shelves" AS s ON u.id = s.user_id
+      JOIN "manuscript_shelf" AS ms ON ms.shelf_id = s.id
+      JOIN "manuscripts" AS m ON m.id = ms.manuscript_id
+      WHERE u.id = $1 AND m.id = $2
+    ) AS is_manuscript_owner;
+    `;
+
+    const isOwnerResult = await connection.query(isManuscriptOwnerQueryText, [
+      userId,
+      manuscriptId,
+    ]);
+    const isOwner = isOwnerResult.rows[0].is_manuscript_owner;
+    console.log("isOwnerBool", isOwner);
+
+    //If the content does not exist or does not belong to the user, we send status 403 forbidden and break.
+    if (!isOwner) {
+      res.sendStatus(403);
+      return;
+    }
+
     const deleteManuscriptShelvesQueryText = `
     DELETE FROM "manuscript_shelf" 
-    USING "user" 
-    WHERE "manuscript_shelf".manuscript_id = $1 AND "user".id = $2;`;
+    WHERE "manuscript_shelf".manuscript_id = $1`;
 
-    await connection.query(deleteManuscriptShelvesQueryText, [
-      manuscriptId,
-      userId,
-    ]);
+    await connection.query(deleteManuscriptShelvesQueryText, [manuscriptId]);
 
     const deleteManuscriptQueryText = `
     DELETE FROM "manuscripts" 
-    USING "user" 
-    WHERE "manuscripts".id = $1 AND "user".id = $2;
+    WHERE "manuscripts".id = $1;
     `;
 
-    await connection.query(deleteManuscriptQueryText, [manuscriptId, userId]);
+    await connection.query(deleteManuscriptQueryText, [manuscriptId]);
 
     await connection.query("COMMIT");
-    res.sendStatus(201);
+    res.sendStatus(204);
   } catch (error) {
     await connection.query("ROLLBACK");
     console.log(`Transaction Error - Rolling back transfer`, error);

--- a/server/routes/manuscript.router.js
+++ b/server/routes/manuscript.router.js
@@ -139,9 +139,6 @@ router.post("/", rejectUnauthenticated, async (req, res) => {
  * PUT Manuscript route
  */
 router.put("/:id", rejectUnauthenticated, async (req, res) => {
-  // const userId = req.user.id;
-
-  console.log("req", req);
 
   const manuscriptId = req.params.id;
   const title = req.body.payload.title;
@@ -170,7 +167,6 @@ router.put("/:id", rejectUnauthenticated, async (req, res) => {
       manuscriptId,
     ]);
     const isOwner = isOwnerResult.rows[0].is_manuscript_owner;
-    console.log("isOwnerBool", isOwner);
 
     //If the content does not exist or does not belong to the user, we send 403 status forbidden and break.
     if (!isOwner) {
@@ -231,7 +227,6 @@ router.delete("/:id", rejectUnauthenticated, async (req, res) => {
       manuscriptId,
     ]);
     const isOwner = isOwnerResult.rows[0].is_manuscript_owner;
-    console.log("isOwnerBool", isOwner);
 
     //If the content does not exist or does not belong to the user, we send status 403 forbidden and break.
     if (!isOwner) {

--- a/src/pages/User/WritersDesk/WritersDeskPage/WritersDeskPage.jsx
+++ b/src/pages/User/WritersDesk/WritersDeskPage/WritersDeskPage.jsx
@@ -34,8 +34,6 @@ function WritersDeskPage() {
       public: isChecked,
     };
 
-    console.log("newManuscript", newManuscript);
-
     dispatch({
       type: "ADD_MANUSCRIPT",
       payload: newManuscript,
@@ -52,7 +50,6 @@ function WritersDeskPage() {
 
   //Deletes Manuscript from Database
   const handleDelete = (id) => {
-    console.log("clicked delete on", id);
 
     dispatch({
       type: "REMOVE_MANUSCRIPT",

--- a/src/redux/sagas/manuscript.saga.js
+++ b/src/redux/sagas/manuscript.saga.js
@@ -6,7 +6,6 @@ import axios from "axios";
  */
 function* fetchPublicManuscriptList() {
   try {
-    // console.log('in list of teams');
     const response = yield axios.get(`/manuscript`);
     yield put({ type: "SET_PUBLIC_MANUSCRIPT_LIST", payload: response.data });
   } catch (error) {
@@ -16,7 +15,6 @@ function* fetchPublicManuscriptList() {
 
 function* fetchWritersDeskList() {
   try {
-    // console.log('in list of teams');
     const response = yield axios.get(`/manuscript/writersdesk`);
     yield put({ type: "SET_WRITERS_DESK_LIST", payload: response.data });
   } catch (error) {
@@ -26,7 +24,6 @@ function* fetchWritersDeskList() {
 
 function* fetchManuscript(action) {
     try {
-        // console.log('in list of teams');
         const response = yield axios.get(`/manuscript/${action.payload}`);
 
         console.log('response.data in saga', response.data);


### PR DESCRIPTION
Added User Shelf creation on user registration. A user has a shelf "${username}_shelf" added to the shelf table with a foreign key pointing to the user table.

Added SELECT exists query before PUT and DELETE to make sure content to be altered exists and is owned by the currently authenticated user. Manuscripts should now be secure from postman attacks.